### PR TITLE
Patches in support for maxBounds

### DIFF
--- a/packages/mapbox/README.md
+++ b/packages/mapbox/README.md
@@ -37,6 +37,24 @@ const CustomMap = (props) => (
 );
 ```
 
+### Setting Map Bounds
+
+Because [react-map-gl doesn't support the `viewport.maxBounds` setting](https://github.com/visgl/react-map-gl/issues/442), support has has been patched in. Pass `maxBounds` on the `defaultViewport` attribute in the form of a [Mapbox LngLatBoundsLike](https://docs.mapbox.com/mapbox-gl-js/api/geography/#lnglatboundslike) array of arrays, `[[lng,lat], [lng,lat]]`.
+
+```js
+{
+  width: 400,
+  height: 400,
+  latitude: 37.7577,
+  longitude: -122.4376,
+  zoom: 8,
+  maxBounds: [
+   [-107.6, 33.8], // [west, south]
+   [-65, 49.9], // [east, north]
+  ],
+}
+```
+
 # Hooks
 
 A collection of hooks are provided to allow access to map viewport information and manipulation.

--- a/packages/mapbox/src/components/Mapbox.js
+++ b/packages/mapbox/src/components/Mapbox.js
@@ -106,6 +106,25 @@ const Mapbox = ({
     (vp) => {
       if (!loaded) return;
       if (vp.zoom && vp.zoom < 2) return;
+      // Patch in support for Mapbox GL viewport.maxBounds, https://github.com/visgl/react-map-gl/issues/442
+      const maxBounds = defaultViewport.maxBounds
+        ? defaultViewport.maxBounds
+        : false;
+      if (!!maxBounds && maxBounds.length > 0) {
+        if (vp.longitude < maxBounds[0][0]) {
+          vp.longitude = maxBounds[0][0];
+        }
+        if (vp.longitude > maxBounds[1][0]) {
+          vp.longitude = maxBounds[1][0];
+        }
+        if (vp.latitude < maxBounds[0][1]) {
+          vp.latitude = maxBounds[0][1];
+        }
+        if (vp.latitude > maxBounds[1][1]) {
+          vp.latitude = maxBounds[1][1];
+        }
+      }
+
       setViewport(vp);
     },
     [setViewport, loaded]

--- a/packages/mapbox/src/components/Mapbox.stories.js
+++ b/packages/mapbox/src/components/Mapbox.stories.js
@@ -1,24 +1,29 @@
-import React from 'react';
+import React from "react";
 
-import Mapbox from './Mapbox';
+import Mapbox from "./Mapbox";
 
 export default {
   component: Mapbox,
-  title: 'Visualization/Mapbox',
+  title: "Visualization/Mapbox",
   args: {
     MapGLProps: {
-      mapboxApiAccessToken: "pk.eyJ1IjoiaHlwZXJvYmpla3QiLCJhIjoiY2pzZ3Bnd3piMGV6YTQzbjVqa3Z3dHQxZyJ9.rHobqsY_BjkNbqNQS4DNYw",
+      mapboxApiAccessToken:
+        "pk.eyJ1IjoiaHlwZXJvYmpla3QiLCJhIjoiY2pzZ3Bnd3piMGV6YTQzbjVqa3Z3dHQxZyJ9.rHobqsY_BjkNbqNQS4DNYw",
     },
-    defaultViewport:{
+    defaultViewport: {
       zoom: 11,
       latitude: 40.74,
-      longitude: -73.96
-    }
-  }
+      longitude: -73.96,
+      // Uncomment to test maxBounds patch.
+      // maxBounds: [
+      //   [-107.6, 33.8],
+      //   [-65, 49.9],
+      // ],
+    },
+  },
 };
 
 /**
  * A base map with no overlays or additional styles
  */
 export const Base = (args) => <Mapbox {...args} />;
-


### PR DESCRIPTION
Patches in support for `maxBounds`, if passed on default viewport. Support for `maxBounds` is not provided by react-map-gl. 
* https://github.com/visgl/react-map-gl/issues/442
* https://visgl.github.io/react-map-gl/docs/api-reference/interactive-map#interaction-options